### PR TITLE
feat: slider calculator design, plan, and project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,12 @@
 
 - **Pre-PR checks**: Run type checks, lint, and tests before creating PRs
 - **Reproducible installs**: Use `npm ci` instead of `npm install` to match CI environment
+
+## Project Structure
+
+- **All dev commands run from `app/`**: `cd app && npm run dev|check|lint|build`
+- **Dev server**: `http://localhost:5173`
+- **Svelte 5 runes**: Use `$state`, `$derived`, `$effect` — not older reactive stores or `$:` syntax
+- **shadcn-svelte components**: Install with `npx shadcn-svelte@latest add <component>` from `app/`
+- **Specs**: `thoughts/specs/` for design/feature specs
+- **Plans**: `docs/plans/` for implementation plans

--- a/docs/plans/2026-02-28-slider-calculator-design.md
+++ b/docs/plans/2026-02-28-slider-calculator-design.md
@@ -1,0 +1,97 @@
+# SquareDeals Slider Calculator — Design
+
+## Summary
+
+A real estate calculator at `/calculator` with three linked sliders (Price, Square Feet, Price Per Sq Ft) that maintain the relationship `Price = SqFt x PricePerSqFt`. A toggle group lets the user choose which value is auto-computed. Built with SvelteKit 5, shadcn-svelte components, and Tailwind CSS 4.
+
+## Behavior
+
+### Core Relationship
+
+```
+Price = Square Feet x Price Per Square Foot
+```
+
+### Mode Selection
+
+A 3-button toggle group (shadcn-svelte ToggleGroup, `type="single"`) lets the user pick which value is auto-computed:
+
+- **Price** — SqFt and PricePerSqFt are user-controlled; Price is derived
+- **Sq Ft** — Price and PricePerSqFt are user-controlled; SqFt is derived
+- **$/Sq Ft** — Price and SqFt are user-controlled; PricePerSqFt is derived
+
+When the mode changes, the previously-computed value freezes at its current value (written back to state), and the newly-selected value starts being derived.
+
+### Slider Rows
+
+Each row contains:
+- **Label** (shadcn-svelte Label)
+- **Slider** (shadcn-svelte Slider, `type="single"`, `bind:value`)
+- **Number Input** (shadcn-svelte Input, `type="number"`, bidirectionally synced with slider)
+- **Badge** (shadcn-svelte Badge) — shows "auto" only on the computed row
+
+The computed row gets `opacity-50` and `pointer-events-none` on its interactive elements.
+
+## Ranges
+
+| Slider         | Min     | Max        | Step   |
+|----------------|---------|------------|--------|
+| Price          | $50,000 | $2,000,000 | $1,000 |
+| Square Feet    | 200     | 10,000     | 10     |
+| Price Per SqFt | $50     | $1,000     | $1     |
+
+## Edge Cases
+
+- **Division by zero**: Clamp denominator to its minimum value before dividing (SqFt min 200, PricePerSqFt min 50)
+- **Out-of-range results**: Clamp computed values to their slider's min/max range
+- **Mode switching**: Freeze the current computed value into state before switching
+
+## Architecture
+
+### Route
+
+```
+app/src/routes/calculator/+page.svelte
+```
+
+No server-side data loading needed — purely client-side calculator.
+
+### State Model (Svelte 5 Runes)
+
+```typescript
+let mode: 'price' | 'sqft' | 'ppsf' = $state('price');
+let price = $state(300000);
+let sqft = $state(1500);
+let ppsf = $state(200);
+```
+
+The computed value is derived using `$derived` based on the current mode. The two non-computed values are directly user-controlled via their sliders/inputs.
+
+### Components Used
+
+| Component    | Source          | Status     |
+|-------------|-----------------|------------|
+| Slider      | shadcn-svelte   | To install |
+| ToggleGroup | shadcn-svelte   | To install |
+| Card        | shadcn-svelte   | Installed  |
+| Input       | shadcn-svelte   | Installed  |
+| Label       | shadcn-svelte   | Installed  |
+| Badge       | shadcn-svelte   | Installed  |
+
+### Layout
+
+Centered column (`max-w-2xl mx-auto`) with:
+1. Page heading: "SquareDeals"
+2. Mode toggle group (3 buttons)
+3. Three slider row cards
+
+### Styling
+
+- Tailwind CSS utility classes throughout
+- shadcn-svelte design tokens (no hardcoded colors)
+- Computed row: reduced opacity + pointer-events-none + visible "auto" badge
+
+## References
+
+- Design spec: `thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md`
+- Original implementation plan (vanilla JS): `thoughts/specs/2026-02-25-real-estate-slider-calculator.md`

--- a/docs/plans/2026-02-28-slider-calculator.md
+++ b/docs/plans/2026-02-28-slider-calculator.md
@@ -1,0 +1,275 @@
+# SquareDeals Slider Calculator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a `/calculator` page with three linked sliders (Price, Square Feet, Price Per Sq Ft) that maintain the relationship `Price = SqFt x PricePerSqFt`, with a toggle group to select which value is auto-computed.
+
+**Architecture:** A single SvelteKit page component using Svelte 5 runes for reactive state. Three `$state` variables hold the slider values, and a `$effect` recomputes the dependent value whenever inputs change. shadcn-svelte components (Slider, ToggleGroup, Card, Input, Label, Badge) provide the UI.
+
+**Tech Stack:** SvelteKit 5, Svelte 5 runes, shadcn-svelte, Tailwind CSS 4
+
+---
+
+### Task 1: Install shadcn-svelte Slider and ToggleGroup Components
+
+**Files:**
+- Created by CLI: `app/src/lib/components/ui/slider/` (new)
+- Created by CLI: `app/src/lib/components/ui/toggle-group/` (new)
+
+**Step 1: Install the slider component**
+
+Run from the `app/` directory:
+
+```bash
+cd app && npx shadcn-svelte@latest add slider
+```
+
+Expected: New files created in `app/src/lib/components/ui/slider/`.
+
+**Step 2: Install the toggle-group component**
+
+```bash
+cd app && npx shadcn-svelte@latest add toggle-group
+```
+
+Expected: New files created in `app/src/lib/components/ui/toggle-group/`.
+
+**Step 3: Verify installation**
+
+```bash
+ls app/src/lib/components/ui/slider/ app/src/lib/components/ui/toggle-group/
+```
+
+Expected: Both directories exist with `.svelte` files and `index.ts`.
+
+**Step 4: Commit**
+
+```bash
+git add app/src/lib/components/ui/slider app/src/lib/components/ui/toggle-group
+git commit -m "feat: install shadcn-svelte slider and toggle-group components"
+```
+
+---
+
+### Task 2: Create the Calculator Page
+
+**Files:**
+- Create: `app/src/routes/calculator/+page.svelte`
+
+**Step 1: Create the route directory**
+
+```bash
+mkdir -p app/src/routes/calculator
+```
+
+**Step 2: Write the calculator page**
+
+Create `app/src/routes/calculator/+page.svelte`:
+
+```svelte
+<script lang="ts">
+	import { Slider } from '$lib/components/ui/slider/index.js';
+	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+
+	type Mode = 'price' | 'sqft' | 'ppsf';
+
+	let mode: Mode = $state('price');
+	let price = $state(300000);
+	let sqft = $state(1500);
+	let ppsf = $state(200);
+
+	function clamp(val: number, min: number, max: number): number {
+		return Math.min(Math.max(val, min), max);
+	}
+
+	function roundTo(val: number, step: number): number {
+		return Math.round(val / step) * step;
+	}
+
+	$effect(() => {
+		if (mode === 'price') {
+			price = roundTo(clamp(sqft * ppsf, 50000, 2000000), 1000);
+		} else if (mode === 'sqft') {
+			sqft = roundTo(clamp(price / Math.max(ppsf, 50), 200, 10000), 10);
+		} else {
+			ppsf = roundTo(clamp(price / Math.max(sqft, 200), 50, 1000), 1);
+		}
+	});
+
+	const sliders = [
+		{ key: 'price' as Mode, label: 'Price ($)', min: 50000, max: 2000000, step: 1000 },
+		{ key: 'sqft' as Mode, label: 'Square Feet', min: 200, max: 10000, step: 10 },
+		{ key: 'ppsf' as Mode, label: 'Price Per Sq Ft ($)', min: 50, max: 1000, step: 1 }
+	] as const;
+
+	function getValue(key: Mode): number {
+		if (key === 'price') return price;
+		if (key === 'sqft') return sqft;
+		return ppsf;
+	}
+
+	function setValue(key: Mode, val: number): void {
+		if (key === 'price') price = val;
+		else if (key === 'sqft') sqft = val;
+		else ppsf = val;
+	}
+</script>
+
+<svelte:head>
+	<title>SquareDeals — Calculator</title>
+</svelte:head>
+
+<div class="mx-auto max-w-2xl px-4 py-10">
+	<h1 class="mb-6 text-2xl font-bold">SquareDeals</h1>
+
+	<div class="mb-8">
+		<Label class="mb-2 block text-sm text-muted-foreground">Auto-compute:</Label>
+		<ToggleGroup.Root type="single" bind:value={mode} variant="outline">
+			<ToggleGroup.Item value="price" aria-label="Auto-compute price">Price</ToggleGroup.Item>
+			<ToggleGroup.Item value="sqft" aria-label="Auto-compute square feet">Sq Ft</ToggleGroup.Item>
+			<ToggleGroup.Item value="ppsf" aria-label="Auto-compute price per square foot">$/Sq Ft</ToggleGroup.Item>
+		</ToggleGroup.Root>
+	</div>
+
+	{#each sliders as s (s.key)}
+		{@const isComputed = mode === s.key}
+		{@const val = getValue(s.key)}
+		<Card.Root class="mb-4 {isComputed ? 'opacity-50' : ''}">
+			<Card.Content class="pt-6">
+				<div class="mb-3 flex items-center justify-between">
+					<Label>{s.label}</Label>
+					{#if isComputed}
+						<Badge variant="secondary">auto</Badge>
+					{/if}
+				</div>
+				<div class={isComputed ? 'pointer-events-none' : ''}>
+					<Slider
+						type="single"
+						value={val}
+						onValueChange={(v) => setValue(s.key, v)}
+						min={s.min}
+						max={s.max}
+						step={s.step}
+						class="mb-3"
+					/>
+					<Input
+						type="number"
+						value={val}
+						oninput={(e) => {
+							const parsed = parseFloat(e.currentTarget.value);
+							if (!isNaN(parsed)) setValue(s.key, clamp(parsed, s.min, s.max));
+						}}
+						min={s.min}
+						max={s.max}
+						step={s.step}
+						class="w-32 text-right"
+					/>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/each}
+</div>
+```
+
+**Key design decisions in this code:**
+
+- **`$effect` for computation**: Reads the two non-computed values and writes the computed one. No infinite loop because the written variable is never read in the same branch.
+- **`roundTo()`**: Rounds computed values to match each slider's step size (Price to nearest $1,000, SqFt to nearest 10, PricePerSqFt to nearest $1).
+- **Mode switching**: When mode changes, the `$effect` re-runs and uses whatever values are currently in state — the previously-computed value naturally freezes at its last value.
+- **`pointer-events-none`**: Prevents interaction with the computed row's slider and input.
+- **`onValueChange` on Slider**: Using the callback prop rather than `bind:value` because the Slider component's `value` prop for `type="single"` might be typed as a single number while `bind:value` might expect array handling. The callback gives us explicit control.
+- **`oninput` on Input**: Using native event handler instead of `bind:value` for the number input so we can parse and clamp the value before updating state.
+
+**Step 3: Run type checking**
+
+```bash
+cd app && npm run check
+```
+
+Expected: No type errors.
+
+**Step 4: Commit**
+
+```bash
+git add app/src/routes/calculator/+page.svelte
+git commit -m "feat: add calculator page with linked sliders"
+```
+
+---
+
+### Task 3: Verify in Browser
+
+**Step 1: Start the dev server**
+
+```bash
+cd app && npm run dev
+```
+
+**Step 2: Open http://localhost:5173/calculator**
+
+**Step 3: Manual verification checklist**
+
+#### Automated Verification:
+
+- [ ] Type checking passes: `npm run check`
+- [ ] Linting passes: `npm run lint`
+
+#### Manual Verification:
+
+- [ ] Page loads with "Price" toggle active and Price row showing "auto" badge at reduced opacity
+- [ ] Moving the SqFt slider updates the Price value
+- [ ] Moving the $/SqFt slider updates the Price value
+- [ ] Clicking "Sq Ft" toggle: SqFt row becomes auto, Price row becomes interactive
+- [ ] Moving Price or $/SqFt sliders updates SqFt value
+- [ ] Clicking "$/Sq Ft" toggle: $/SqFt row becomes auto
+- [ ] Moving Price or SqFt sliders updates $/SqFt value
+- [ ] Typing in a number input updates the corresponding slider position
+- [ ] Computed values stay within their min/max range
+- [ ] Computed row's slider and input are not interactive (pointer-events-none)
+
+**Implementation Note**: After completing this task and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful.
+
+---
+
+### Task 4: Fix Issues and Final Commit
+
+After manual verification, address any issues found. This task is only needed if adjustments are required from Task 3 manual testing.
+
+**Step 1: Fix any identified issues**
+
+Make targeted fixes based on manual testing feedback.
+
+**Step 2: Run checks**
+
+```bash
+cd app && npm run check && npm run lint
+```
+
+**Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "fix: address calculator feedback from manual testing"
+```
+
+---
+
+## What We're NOT Doing
+
+- No server-side data loading (purely client-side calculator)
+- No database changes
+- No unit or e2e tests (unless explicitly requested)
+- No dark mode support beyond what shadcn-svelte provides by default
+- No URL parameter persistence for slider values
+- No changes to the root page or layout
+- No number formatting (commas, dollar signs) in inputs
+
+## References
+
+- Design doc: `docs/plans/2026-02-28-slider-calculator-design.md`
+- Original design spec: `thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md`
+- Original vanilla JS plan: `thoughts/specs/2026-02-25-real-estate-slider-calculator.md`

--- a/thoughts/shared/research/2026-02-28-specs-overview.md
+++ b/thoughts/shared/research/2026-02-28-specs-overview.md
@@ -1,0 +1,95 @@
+---
+date: 2026-02-28T00:00:00-06:00
+git_commit: 412293607bcaf1cffc930a447d7c4357e621d3db
+branch: main
+repository: GaryGealy/humanlayer-scaffolding
+topic: "Specs folder overview — Real Estate Slider Calculator"
+---
+
+# Research: Specs Folder Overview
+
+**Date**: 2026-02-28
+**Git Commit**: `4122936`
+**Branch**: main
+
+## Research Question
+
+What do the two markdown files in the specs folder contain, and how do they relate to the current codebase?
+
+## Summary
+
+The `thoughts/specs/` directory contains two documents that together define SquareDeals — a real estate price calculator with three linked sliders. One document is a **design spec** (behavior, ranges, edge cases), the other is a **step-by-step implementation plan** (HTML, CSS, JS). The implementation plan targets a standalone `index.html` with vanilla JS — notably different from the project's actual tech stack, which is SvelteKit 5 + Tailwind CSS 4 + shadcn-svelte deployed to Cloudflare Pages. No implementation of the calculator exists in the codebase yet.
+
+## Detailed Findings
+
+### Document 1: Design Spec
+
+**File**: `thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md`
+
+A concise product spec defining:
+
+- **Core concept**: Three sliders (Price, Square Feet, Price Per Sq Ft) with bidirectionally synced text inputs
+- **Mathematical relationship**: `Price = Square Feet x Price Per Sq Foot`
+- **Mode button**: Cycles which of the three values is the computed (dependent) output
+  - Mode 1: Price auto-updates from SqFt x PricePerSqFt
+  - Mode 2: Square Feet auto-updates from Price / PricePerSqFt
+  - Mode 3: Price Per Sq Foot auto-updates from Price / SqFt
+- **Ranges**:
+
+  | Slider         | Min     | Max        | Step   |
+  |----------------|---------|------------|--------|
+  | Price          | $50,000 | $2,000,000 | $1,000 |
+  | Square Feet    | 200     | 10,000     | 10     |
+  | Price Per SqFt | $50     | $1,000     | $1     |
+
+- **Edge case handling**: Division by zero is prevented by clamping the denominator to its minimum value before dividing
+- **Implementation constraint**: Vanilla JS, single HTML file, no dependencies
+
+### Document 2: Implementation Plan
+
+**File**: `thoughts/specs/2026-02-25-real-estate-slider-calculator.md`
+
+A three-task implementation plan with full code listings:
+
+- **Task 1 — HTML Skeleton** (lines 13-68): Creates `index.html` with a mode button, three `.slider-row` divs each containing a label, range input, number input, and "auto" badge
+- **Task 2 — CSS Styling** (lines 70-168): Grid-based layout (160px label / 1fr slider / 110px number / 48px badge), white card rows with shadow, blue accent color (`#4a90d9`), `.is-computed` class greys out the auto-calculated row and shows the badge
+- **Task 3 — JavaScript Logic** (lines 170-277): A `sliders` object maps keys (`price`, `sqft`, `ppsf`) to their DOM elements. A `modes` array and `currentMode` index track which value is computed. `compute()` recalculates the dependent value with clamping. Bidirectional event listeners sync each slider/text pair. The mode button cycles through modes on click.
+
+The plan instructs using `superpowers:executing-plans` to implement task-by-task.
+
+### Current Codebase State
+
+The project is a SvelteKit 5 scaffold with:
+- Svelte 5, TypeScript, Tailwind CSS 4, shadcn-svelte (new-york style)
+- Cloudflare Pages deployment via `@sveltejs/adapter-cloudflare`
+- D1 database binding in `wrangler.toml`
+- Pre-installed UI components: accordion, badge, button, card, checkbox, dialog, input, label, select, separator, skeleton, switch, tooltip
+- Default SvelteKit boilerplate at `app/src/routes/+page.svelte` — no custom application code
+
+### Gap Between Spec and Codebase
+
+The implementation plan calls for a standalone `index.html` with vanilla JS. The actual project uses SvelteKit with Svelte components, Tailwind CSS, and shadcn-svelte. If the calculator is built per the spec, it would live outside the SvelteKit app. Alternatively, it could be reimplemented as a Svelte component using the project's existing tech stack and UI library — the spec's logic (mode cycling, compute function, bidirectional sync) would translate directly to Svelte reactivity.
+
+## Code References
+
+- `thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md` — Product design spec (36 lines)
+- `thoughts/specs/2026-02-25-real-estate-slider-calculator.md` — Implementation plan with full code (278 lines)
+- `app/src/routes/+page.svelte` — Current root page (default SvelteKit boilerplate)
+- `app/src/app.css` — Global styles with shadcn-svelte tokens
+- `app/package.json` — Full dependency manifest
+
+## Architecture Documentation
+
+The spec defines a simple architecture: a single HTML file with inline CSS and JS. Three DOM elements per slider (range, number, badge) are wired with `input` event listeners. A central `compute()` function enforces `Price = SqFt x PricePerSqFt` by recalculating whichever variable is in "auto" mode. The mode button cycles a `currentMode` index that determines which variable is computed.
+
+## Historical Context (from thoughts/)
+
+- `thoughts/tech-stack.md` — Documents the project's intended tech stack
+- `thoughts/ReadMe.md` — Overview of the thoughts directory purpose
+- `thoughts/specs/` — Contains the two spec documents researched here
+
+## Open Questions
+
+- Should the calculator be built as a standalone `index.html` per the spec, or adapted to SvelteKit/Svelte 5 components using the existing tech stack?
+- The spec uses hardcoded blue (`#4a90d9`) styling while the project has shadcn-svelte design tokens — which should be used?
+- Where should the calculator live within the SvelteKit routing structure (e.g., root page at `/`, or a dedicated route)?

--- a/thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md
+++ b/thoughts/specs/2026-02-25-real-estate-slider-calculator-design.md
@@ -1,0 +1,35 @@
+# SquareDeals — Design
+
+## Summary
+
+A single self-contained `index.html` file that lets users explore the relationship between
+Price, Square Feet, and Price Per Square Foot using synchronized sliders and text inputs.
+
+## Behavior
+
+Three sliders, each with a bidirectionally synced text box to the right.
+
+Mathematical relationship: `Price = Square Feet × Price Per Sq Foot`
+
+A **Mode button** cycles through which slider is the computed (dependent) output:
+- Mode 1: **Price** auto-updates (SqFt × PricePerSqFt → Price)
+- Mode 2: **Square Feet** auto-updates (Price ÷ PricePerSqFt → SqFt)
+- Mode 3: **Price Per Sq Foot** auto-updates (Price ÷ SqFt → PricePerSqFt)
+
+The computed slider and text box are visually indicated (greyed out / labeled "auto").
+
+## Ranges
+
+| Slider          | Min    | Max    | Step  |
+|-----------------|--------|--------|-------|
+| Price           | $50,000 | $2,000,000 | $1,000 |
+| Square Feet     | 200    | 10,000 | 10    |
+| Price Per SqFt  | $50    | $1,000 | $1    |
+
+## Edge Cases
+
+- Division by zero: clamp denominator to its minimum value before dividing.
+
+## Implementation
+
+- Vanilla JS, single HTML file, no dependencies.

--- a/thoughts/specs/2026-02-25-real-estate-slider-calculator.md
+++ b/thoughts/specs/2026-02-25-real-estate-slider-calculator.md
@@ -1,0 +1,277 @@
+# SquareDeals Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a single `index.html` page with three linked sliders (Price, Square Feet, Price Per Sq Foot) that maintain the relationship Price = SqFt × PricePerSqFt, with a mode button cycling which slider is the computed output.
+
+**Architecture:** Single self-contained HTML file. Vanilla JS handles bidirectional sync between each slider and its text input, and recalculates the dependent slider on every change. A mode button cycles through 3 modes (one per dependent variable).
+
+**Tech Stack:** HTML, CSS, vanilla JavaScript — no dependencies.
+
+---
+
+### Task 1: HTML Skeleton
+
+**Files:**
+- Create: `index.html`
+
+**Step 1: Create the file with the basic structure**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SquareDeals</title>
+  <style>
+    /* placeholder */
+  </style>
+</head>
+<body>
+  <h1>SquareDeals</h1>
+
+  <div id="mode-bar">
+    <button id="mode-btn">Mode: Price is computed</button>
+  </div>
+
+  <div class="slider-row" id="row-price">
+    <label>Price ($)</label>
+    <input type="range" id="slider-price" min="50000" max="2000000" step="1000" value="300000">
+    <input type="number" id="text-price" min="50000" max="2000000" step="1000" value="300000">
+    <span class="auto-badge" id="badge-price">auto</span>
+  </div>
+
+  <div class="slider-row" id="row-sqft">
+    <label>Square Feet</label>
+    <input type="range" id="slider-sqft" min="200" max="10000" step="10" value="1500">
+    <input type="number" id="text-sqft" min="200" max="10000" step="10" value="1500">
+    <span class="auto-badge" id="badge-sqft">auto</span>
+  </div>
+
+  <div class="slider-row" id="row-ppsf">
+    <label>Price Per Sq Ft ($)</label>
+    <input type="range" id="slider-ppsf" min="50" max="1000" step="1" value="200">
+    <input type="number" id="text-ppsf" min="50" max="1000" step="1" value="200">
+    <span class="auto-badge" id="badge-ppsf">auto</span>
+  </div>
+
+  <script>
+    // placeholder
+  </script>
+</body>
+</html>
+```
+
+**Step 2: Open in browser and verify the structure renders**
+
+Open `index.html` in a browser. You should see a heading, a mode button, and 3 slider rows each with a range input, number input, and an "auto" badge.
+
+---
+
+### Task 2: CSS Styling
+
+**Files:**
+- Modify: `index.html` — replace `/* placeholder */` in `<style>`
+
+**Step 1: Add layout and visual styles**
+
+```css
+*, *::before, *::after { box-sizing: border-box; }
+
+body {
+  font-family: system-ui, sans-serif;
+  max-width: 640px;
+  margin: 40px auto;
+  padding: 0 20px;
+  background: #f5f5f5;
+  color: #222;
+}
+
+h1 { font-size: 1.4rem; margin-bottom: 24px; }
+
+#mode-bar {
+  margin-bottom: 28px;
+}
+
+#mode-btn {
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border: 2px solid #4a90d9;
+  background: #fff;
+  border-radius: 6px;
+  color: #4a90d9;
+  font-weight: 600;
+  transition: background 0.15s, color 0.15s;
+}
+
+#mode-btn:hover {
+  background: #4a90d9;
+  color: #fff;
+}
+
+.slider-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 110px 48px;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding: 14px 16px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  transition: opacity 0.2s;
+}
+
+.slider-row label { font-weight: 600; font-size: 0.9rem; }
+
+input[type="range"] { width: 100%; accent-color: #4a90d9; }
+
+input[type="number"] {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+.auto-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: #fff;
+  background: #4a90d9;
+  border-radius: 4px;
+  padding: 2px 6px;
+  visibility: hidden; /* shown via JS when row is computed */
+}
+
+.slider-row.is-computed {
+  opacity: 0.7;
+}
+
+.slider-row.is-computed .auto-badge {
+  visibility: visible;
+}
+
+.slider-row.is-computed input[type="range"],
+.slider-row.is-computed input[type="number"] {
+  pointer-events: none;
+}
+```
+
+**Step 2: Verify in browser**
+
+Reload. The rows should be white cards with a label, slider, number box, and hidden badge. The mode button should be styled with a blue border.
+
+---
+
+### Task 3: JavaScript Logic
+
+**Files:**
+- Modify: `index.html` — replace `// placeholder` in `<script>`
+
+**Step 1: Add the full JS**
+
+```javascript
+const sliders = {
+  price: { slider: document.getElementById('slider-price'), text: document.getElementById('text-price'), row: document.getElementById('row-price'), badge: document.getElementById('badge-price') },
+  sqft:  { slider: document.getElementById('slider-sqft'),  text: document.getElementById('text-sqft'),  row: document.getElementById('row-sqft'),  badge: document.getElementById('badge-sqft') },
+  ppsf:  { slider: document.getElementById('slider-ppsf'),  text: document.getElementById('text-ppsf'),  row: document.getElementById('row-ppsf'),  badge: document.getElementById('badge-ppsf') },
+};
+
+// modes[i] = which key is the computed (dependent) slider
+const modes = ['price', 'sqft', 'ppsf'];
+const modeLabels = ['Price is computed', 'Sq Ft is computed', 'Price/SqFt is computed'];
+let currentMode = 0;
+
+const modeBtn = document.getElementById('mode-btn');
+
+function getValues() {
+  return {
+    price: parseFloat(sliders.price.slider.value),
+    sqft:  parseFloat(sliders.sqft.slider.value),
+    ppsf:  parseFloat(sliders.ppsf.slider.value),
+  };
+}
+
+function clamp(val, min, max) {
+  return Math.min(Math.max(val, min), max);
+}
+
+function compute() {
+  const computed = modes[currentMode];
+  const v = getValues();
+
+  let result;
+  if (computed === 'price') {
+    result = v.sqft * v.ppsf;
+    result = clamp(result, 50000, 2000000);
+    setValue('price', result);
+  } else if (computed === 'sqft') {
+    const denom = Math.max(v.ppsf, 50); // avoid div by zero
+    result = v.price / denom;
+    result = clamp(result, 200, 10000);
+    setValue('sqft', result);
+  } else {
+    const denom = Math.max(v.sqft, 200); // avoid div by zero
+    result = v.price / denom;
+    result = clamp(result, 50, 1000);
+    setValue('ppsf', result);
+  }
+}
+
+function setValue(key, val) {
+  const rounded = Math.round(val);
+  sliders[key].slider.value = rounded;
+  sliders[key].text.value = rounded;
+}
+
+function applyModeUI() {
+  const computed = modes[currentMode];
+  for (const key of Object.keys(sliders)) {
+    sliders[key].row.classList.toggle('is-computed', key === computed);
+  }
+  modeBtn.textContent = 'Mode: ' + modeLabels[currentMode];
+}
+
+modeBtn.addEventListener('click', () => {
+  currentMode = (currentMode + 1) % modes.length;
+  applyModeUI();
+  compute();
+});
+
+// Wire up each slider and text input
+for (const [key, els] of Object.entries(sliders)) {
+  els.slider.addEventListener('input', () => {
+    els.text.value = els.slider.value;
+    compute();
+  });
+
+  els.text.addEventListener('input', () => {
+    const val = parseFloat(els.text.value);
+    if (!isNaN(val)) {
+      els.slider.value = val;
+      compute();
+    }
+  });
+}
+
+// Initialize
+applyModeUI();
+compute();
+```
+
+**Step 2: Verify in browser**
+
+1. Page loads with Price in "auto" mode (greyed, badge visible)
+2. Move the SqFt slider → Price updates
+3. Move the PricePerSqFt slider → Price updates
+4. Click Mode button → Sq Ft becomes computed
+5. Move Price or PricePerSqFt → SqFt updates
+6. Click Mode again → PricePerSqFt becomes computed
+7. Type a value into a text box → corresponding slider moves, computed value updates
+
+---


### PR DESCRIPTION
## Summary

- Add design doc (`docs/plans/2026-02-28-slider-calculator-design.md`) for the SquareDeals real estate slider calculator, adapted for SvelteKit 5 + shadcn-svelte
- Add implementation plan (`docs/plans/2026-02-28-slider-calculator.md`) with step-by-step tasks, complete code, and verification steps
- Add original specs (`thoughts/specs/`) — design spec and vanilla JS implementation plan from Feb 25
- Add research document (`thoughts/shared/research/`) summarizing the specs and their relationship to the existing codebase
- Update `CLAUDE.md` with project structure conventions (app/ subdirectory, Svelte 5 runes, shadcn-svelte install, spec/plan directories)

## Test plan

- [ ] Review design doc and implementation plan for accuracy
- [ ] Confirm CLAUDE.md additions are correct and concise