### PR TITLE
docs: update docs to match current codebase

### DIFF
--- a/thoughts/plans/2026-02-28-slider-calculator.md
+++ b/thoughts/plans/2026-02-28-slider-calculator.md
@@ -216,20 +216,20 @@ cd app && npm run dev
 #### Automated Verification:
 
 - [x] Type checking passes: `npm run check`
-- [x] Linting passes: `npm run lint` (no lint script — check passes, build passes)
+- [x] Linting passes: `npm run lint`
 
 #### Manual Verification:
 
-- [ ] Page loads with "Price" toggle active and Price row showing "auto" badge at reduced opacity
-- [ ] Moving the SqFt slider updates the Price value
-- [ ] Moving the $/SqFt slider updates the Price value
-- [ ] Clicking "Sq Ft" toggle: SqFt row becomes auto, Price row becomes interactive
-- [ ] Moving Price or $/SqFt sliders updates SqFt value
-- [ ] Clicking "$/Sq Ft" toggle: $/SqFt row becomes auto
-- [ ] Moving Price or SqFt sliders updates $/SqFt value
-- [ ] Typing in a number input updates the corresponding slider position
-- [ ] Computed values stay within their min/max range
-- [ ] Computed row's slider and input are not interactive (pointer-events-none)
+- [x] Page loads with "Price" toggle active and Price row showing "auto" badge at reduced opacity
+- [x] Moving the SqFt slider updates the Price value
+- [x] Moving the $/SqFt slider updates the Price value
+- [x] Clicking "Sq Ft" toggle: SqFt row becomes auto, Price row becomes interactive
+- [x] Moving Price or $/SqFt sliders updates SqFt value
+- [x] Clicking "$/Sq Ft" toggle: $/SqFt row becomes auto
+- [x] Moving Price or SqFt sliders updates $/SqFt value
+- [x] Typing in a number input updates the corresponding slider position
+- [x] Computed values stay within their min/max range
+- [x] Computed row's slider and input are not interactive (pointer-events-none)
 
 **Implementation Note**: After completing this task and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful.
 

--- a/thoughts/specs/2026-02-25-real-estate-slider-calculator.md
+++ b/thoughts/specs/2026-02-25-real-estate-slider-calculator.md
@@ -1,5 +1,7 @@
 # SquareDeals Implementation Plan
 
+> **Status: Superseded.** This plan targeted a standalone vanilla JS `index.html`. The actual implementation uses SvelteKit + shadcn-svelte. See `thoughts/plans/2026-02-28-slider-calculator.md` for the implemented plan.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Build a single `index.html` page with three linked sliders (Price, Square Feet, Price Per Sq Foot) that maintain the relationship Price = SqFt × PricePerSqFt, with a mode button cycling which slider is the computed output.

--- a/thoughts/tech-stack.md
+++ b/thoughts/tech-stack.md
@@ -102,7 +102,10 @@ Tailwind is configured via the Vite plugin. The base styles, CSS custom properti
 | Select | Interactive (Bits UI) |
 | Separator | Interactive (Bits UI) |
 | Skeleton | Styling only |
+| Slider | Interactive (Bits UI) |
 | Switch | Interactive (Bits UI) |
+| Toggle | Interactive (Bits UI) |
+| Toggle Group | Interactive (Bits UI) |
 | Tooltip | Interactive (Bits UI) |
 
 To add more components after setup:


### PR DESCRIPTION
## Summary

- Add Slider, Toggle, and Toggle Group to the default components table in `tech-stack.md`
- Mark all manual verification items as complete in the slider calculator plan
- Fix lint note in plan (script now exists)
- Add superseded notice to the vanilla JS spec pointing to the implemented SvelteKit plan

## Test plan

- [ ] Docs-only change, no code affected