### PR TITLE
fix: add test:unit script and vitest browser config

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -41,6 +41,7 @@
 				"@types/bcryptjs": "^2.4.6",
 				"@types/better-sqlite3": "^7.6.13",
 				"@vitest/browser": "^4.0.18",
+				"@vitest/browser-playwright": "^4.0.18",
 				"drizzle-kit": "^0.31.9",
 				"eslint": "^10.0.2",
 				"eslint-config-prettier": "^10.1.8",
@@ -3152,6 +3153,31 @@
 				"vitest": "4.0.18"
 			}
 		},
+		"node_modules/@vitest/browser-playwright": {
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.18.tgz",
+			"integrity": "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@vitest/browser": "4.0.18",
+				"@vitest/mocker": "4.0.18",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"playwright": "*",
+				"vitest": "4.0.18"
+			},
+			"peerDependenciesMeta": {
+				"playwright": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.18",
 			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -5779,7 +5805,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"test:unit": "vitest"
 	},
 	"devDependencies": {
 		"@axe-core/playwright": "^4.11.1",
@@ -29,6 +30,7 @@
 		"@types/bcryptjs": "^2.4.6",
 		"@types/better-sqlite3": "^7.6.13",
 		"@vitest/browser": "^4.0.18",
+		"@vitest/browser-playwright": "^4.0.18",
 		"drizzle-kit": "^0.31.9",
 		"eslint": "^10.0.2",
 		"eslint-config-prettier": "^10.1.8",

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,16 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [svelte()],
+	test: {
+		passWithNoTests: true,
+		browser: {
+			enabled: true,
+			provider: playwright(),
+			headless: true,
+			instances: [{ browser: 'chromium' }]
+		}
+	}
+});


### PR DESCRIPTION
## Summary

Fixes #5 — CI was failing with `Missing script: "test:unit"`.

- Add `test:unit` npm script to `package.json`
- Add `vitest.config.ts` with browser mode (Playwright/Chromium) and `passWithNoTests: true` so CI passes before any unit tests are written
- Install `@vitest/browser-playwright` provider (required by vitest 4.x for browser mode)

The project already had `vitest`, `@vitest/browser`, and `vitest-browser-svelte` installed — just missing the script and config wiring.

## Test plan

- [x] `npm run test:unit -- --run` exits with code 0 locally (no tests found, passes cleanly)
- [x] `npm run check` passes (no type errors)
- [x] `npm run lint` passes