### PR TITLE
feat: add logo to navbar

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -12,7 +12,10 @@
 
 <header class="border-b">
 	<nav class="mx-auto flex max-w-4xl items-center gap-6 px-4 py-3">
-		<a href="/" class="font-semibold tracking-tight">SquareDeals</a>
+		<a href="/" class="flex items-center gap-2 font-semibold tracking-tight">
+			<img src="/square-deals-logo.png" alt="SquareDeals logo" class="h-8 w-auto" />
+			SquareDeals
+		</a>
 		{#each tools as tool}
 			<a
 				href={tool.href}


### PR DESCRIPTION
## Summary
- Add `square-deals-logo.png` from `static/` to the left side of the nav bar
- Logo displays alongside the "SquareDeals" brand text as a flex row

## Test Plan
- [ ] Logo appears on the left of the nav bar on all pages
- [ ] Logo and "SquareDeals" text are side by side
- [ ] Clicking the logo/text still navigates to `/`