### PR TITLE
feat: remove toggle, make price and ppsf sliders always linked

### DIFF
--- a/app/src/routes/calculator/+page.svelte
+++ b/app/src/routes/calculator/+page.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
 	import { Slider } from '$lib/components/ui/slider/index.js';
-	import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Badge } from '$lib/components/ui/badge/index.js';
 
-	type Mode = 'price' | 'ppsf';
-
-	let mode: Mode = $state('price');
 	let price = $state(300000);
 	let sqft = $state(1500);
 	let ppsf = $state(200);
@@ -21,27 +16,19 @@
 		return Math.round(val / step) * step;
 	}
 
-	$effect(() => {
-		if (mode === 'price') {
-			price = roundTo(clamp(sqft * ppsf, 50000, 2000000), 1000);
-		} else {
-			ppsf = roundTo(clamp(price / Math.max(sqft, 200), 50, 1000), 1);
-		}
-	});
-
-	const sliders = [
-		{ key: 'price' as Mode, label: 'Price ($)', min: 50000, max: 2000000, step: 1000 },
-		{ key: 'ppsf' as Mode, label: 'Price Per Sq Ft ($)', min: 50, max: 1000, step: 1 }
-	] as const;
-
-	function getValue(key: Mode): number {
-		if (key === 'price') return price;
-		return ppsf;
+	function onPriceChange(val: number) {
+		price = val;
+		ppsf = roundTo(clamp(price / Math.max(sqft, 200), 50, 1000), 1);
 	}
 
-	function setValue(key: Mode, val: number): void {
-		if (key === 'price') price = val;
-		else ppsf = val;
+	function onPpsfChange(val: number) {
+		ppsf = val;
+		price = roundTo(clamp(sqft * ppsf, 50000, 2000000), 1000);
+	}
+
+	function onSqftChange(val: number) {
+		sqft = val;
+		price = roundTo(clamp(sqft * ppsf, 50000, 2000000), 1000);
 	}
 </script>
 
@@ -51,16 +38,6 @@
 
 <div class="mx-auto max-w-2xl px-4 py-10">
 	<h1 class="mb-6 text-2xl font-bold">SquareDeals</h1>
-
-	<div class="mb-8">
-		<Label class="text-muted-foreground mb-2 block text-sm">Auto-compute:</Label>
-		<ToggleGroup.Root type="single" bind:value={mode} variant="outline">
-			<ToggleGroup.Item value="price" aria-label="Auto-compute price">Price</ToggleGroup.Item>
-			<ToggleGroup.Item value="ppsf" aria-label="Auto-compute price per square foot"
-				>$/Sq Ft</ToggleGroup.Item
-			>
-		</ToggleGroup.Root>
-	</div>
 
 	<Card.Root class="mb-4">
 		<Card.Content class="pt-6">
@@ -72,7 +49,7 @@
 				value={sqft}
 				oninput={(e) => {
 					const parsed = parseFloat(e.currentTarget.value);
-					if (!isNaN(parsed)) sqft = clamp(parsed, 200, 10000);
+					if (!isNaN(parsed)) onSqftChange(clamp(parsed, 200, 10000));
 				}}
 				min={200}
 				max={10000}
@@ -82,41 +59,61 @@
 		</Card.Content>
 	</Card.Root>
 
-	{#each sliders as s (s.key)}
-		{@const isComputed = mode === s.key}
-		{@const val = getValue(s.key)}
-		<Card.Root class="mb-4 {isComputed ? 'opacity-50' : ''}">
-			<Card.Content class="pt-6">
-				<div class="mb-3 flex items-center justify-between">
-					<Label>{s.label}</Label>
-					{#if isComputed}
-						<Badge variant="secondary">auto</Badge>
-					{/if}
-				</div>
-				<div class={isComputed ? 'pointer-events-none' : ''}>
-					<Slider
-						type="single"
-						value={val}
-						onValueChange={(v: number) => setValue(s.key, v)}
-						min={s.min}
-						max={s.max}
-						step={s.step}
-						class="mb-3"
-					/>
-					<Input
-						type="number"
-						value={val}
-						oninput={(e) => {
-							const parsed = parseFloat(e.currentTarget.value);
-							if (!isNaN(parsed)) setValue(s.key, clamp(parsed, s.min, s.max));
-						}}
-						min={s.min}
-						max={s.max}
-						step={s.step}
-						class="w-32 text-right"
-					/>
-				</div>
-			</Card.Content>
-		</Card.Root>
-	{/each}
+	<Card.Root class="mb-4">
+		<Card.Content class="pt-6">
+			<div class="mb-3">
+				<Label>Price ($)</Label>
+			</div>
+			<Slider
+				type="single"
+				value={price}
+				onValueChange={onPriceChange}
+				min={50000}
+				max={2000000}
+				step={1000}
+				class="mb-3"
+			/>
+			<Input
+				type="number"
+				value={price}
+				oninput={(e) => {
+					const parsed = parseFloat(e.currentTarget.value);
+					if (!isNaN(parsed)) onPriceChange(clamp(parsed, 50000, 2000000));
+				}}
+				min={50000}
+				max={2000000}
+				step={1000}
+				class="w-32 text-right"
+			/>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="mb-4">
+		<Card.Content class="pt-6">
+			<div class="mb-3">
+				<Label>Price Per Sq Ft ($)</Label>
+			</div>
+			<Slider
+				type="single"
+				value={ppsf}
+				onValueChange={onPpsfChange}
+				min={50}
+				max={1000}
+				step={1}
+				class="mb-3"
+			/>
+			<Input
+				type="number"
+				value={ppsf}
+				oninput={(e) => {
+					const parsed = parseFloat(e.currentTarget.value);
+					if (!isNaN(parsed)) onPpsfChange(clamp(parsed, 50, 1000));
+				}}
+				min={50}
+				max={1000}
+				step={1}
+				class="w-32 text-right"
+			/>
+		</Card.Content>
+	</Card.Root>
 </div>


### PR DESCRIPTION
Closes #14

## Summary
- Remove the auto-compute toggle and mode logic entirely
- Both Price and Price Per Sq Ft sliders are always active
- Sliders are always linked: changing Price updates Price/Sq Ft, and vice versa
- Changing Square Feet updates Price (keeping Price/Sq Ft fixed)

## Test Plan
- [ ] No toggle visible on the calculator page
- [ ] Both sliders are always enabled (no greyed-out / pointer-events-none state)
- [ ] Dragging the Price slider updates Price Per Sq Ft in real time
- [ ] Dragging the Price Per Sq Ft slider updates Price in real time
- [ ] Typing in the Square Feet box updates Price in real time